### PR TITLE
Optimize helper utilities for efficiency

### DIFF
--- a/DragonBurn-usermode/Helpers/Format.h
+++ b/DragonBurn-usermode/Helpers/Format.h
@@ -1,16 +1,17 @@
 #pragma once
+#include <cstdio>
 #include <string>
+#include <utility>
 
 template <typename... Args>
-inline std::string Format(const char* pFormat, Args...args)
+inline std::string Format(const char* pFormat, Args&&... args)
 {
-	int Length = std::snprintf(nullptr, 0, pFormat, args...);
-	if (Length <= 0)
-		return "";
-	char* Str = new char[Length + 1];
-	std::string Result;
-	std::snprintf(Str, Length + 1, pFormat, args...);
-	Result = std::string(Str);
-	delete[] Str;
-	return Result;
+        const int Length = std::snprintf(nullptr, 0, pFormat, std::forward<Args>(args)...);
+        if (Length <= 0)
+                return {};
+
+        std::string Result(static_cast<std::size_t>(Length) + 1, '\0');
+        std::snprintf(Result.data(), Result.size(), pFormat, std::forward<Args>(args)...);
+        Result.resize(static_cast<std::size_t>(Length));
+        return Result;
 }

--- a/DragonBurn-usermode/Helpers/GetWeaponIcon.h
+++ b/DragonBurn-usermode/Helpers/GetWeaponIcon.h
@@ -1,8 +1,8 @@
 ﻿#pragma once
-#include <string>
-#include <map>
+#include <string_view>
+#include <unordered_map>
 
-static const std::unordered_map<std::string, const char*> gunIcons = 
+static const std::unordered_map<std::string_view, const char*> gunIcons =
 {
     {"ct_knife", "]"},
     {"t_knife", "["},
@@ -50,11 +50,11 @@ static const std::unordered_map<std::string, const char*> gunIcons =
 };
 
 // https://www.unknowncheats.me/forum/counter-strike-2-a/608799-weapon-icon-esp.html
-const char* GunIcon(const std::string weapon)
+inline const char* GunIcon(std::string_view weapon)
 {
-	auto it = gunIcons.find(weapon);
-	if (it != gunIcons.end()) {
-		return it->second;
-	}
-	return "";
+        auto it = gunIcons.find(weapon);
+        if (it != gunIcons.end()) {
+                return it->second;
+        }
+        return "";
 }

--- a/DragonBurn-usermode/Helpers/Logger.h
+++ b/DragonBurn-usermode/Helpers/Logger.h
@@ -1,42 +1,41 @@
 #pragma once
-#include <string>
-#include <iostream>
-#include <Windows.h>
 #include <fstream>
+#include <iostream>
+#include <string_view>
+#include <Windows.h>
 
 namespace Log 
 {
-	const HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-	const std::string LogFile = "Logs.txt";
+        inline const HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        inline constexpr std::string_view LogFile = "Logs.txt";
 
-	inline bool WriteLog(std::string ctx)
-	{
-		std::ofstream file(LogFile, std::ios::app);
-		if (!file.is_open())
-			return false;
+        inline bool WriteLog(std::string_view ctx)
+        {
+                std::ofstream file(LogFile.data(), std::ios::app | std::ios::binary);
+                if (!file.is_open())
+                        return false;
 
-		file << ctx;
-		file.close();
+                file.write(ctx.data(), static_cast<std::streamsize>(ctx.size()));
 
-		return true;
+                return true;
 
-	}
+        }
 
-	inline void Info(std::string ctx) 
-	{
-		SetConsoleTextAttribute(hConsole, 11);
-		std::cout << "[i]";
+        inline void Info(std::string_view ctx)
+        {
+                SetConsoleTextAttribute(hConsole, 11);
+                std::cout << "[i]";
 
-		SetConsoleTextAttribute(hConsole, 7);
+                SetConsoleTextAttribute(hConsole, 7);
 		std::cout << ctx << '\n';
 	}
 
-	inline void Warning(std::string ctx, bool pause = false)
-	{
-		SetConsoleTextAttribute(hConsole, 14);
-		std::cout << "[!]";
+        inline void Warning(std::string_view ctx, bool pause = false)
+        {
+                SetConsoleTextAttribute(hConsole, 14);
+                std::cout << "[!]";
 
-		SetConsoleTextAttribute(hConsole, 7);
+                SetConsoleTextAttribute(hConsole, 7);
 		std::cout << ctx << '\n';
 
 		if (pause) 
@@ -46,12 +45,12 @@ namespace Log
 		}
 	}
 
-	inline void Error(std::string ctx, bool fatal = true)
-	{
-		SetConsoleTextAttribute(hConsole, 12);
-		std::cout << "[X]";
+        inline void Error(std::string_view ctx, bool fatal = true)
+        {
+                SetConsoleTextAttribute(hConsole, 12);
+                std::cout << "[X]";
 
-		SetConsoleTextAttribute(hConsole, 7);
+                SetConsoleTextAttribute(hConsole, 7);
 		std::cout << ctx << '\n';
 
 		SetConsoleTextAttribute(hConsole, 8);
@@ -61,46 +60,49 @@ namespace Log
 			exit(-1);
 	}
 
-	inline void Fine(std::string ctx)
-	{
-		SetConsoleTextAttribute(hConsole, 2);
-		std::cout << "[+]";
+        inline void Fine(std::string_view ctx)
+        {
+                SetConsoleTextAttribute(hConsole, 2);
+                std::cout << "[+]";
 
-		SetConsoleTextAttribute(hConsole, 7);
-		std::cout << ctx << '\n';
-	}
+                SetConsoleTextAttribute(hConsole, 7);
+                std::cout << ctx << '\n';
+        }
 
-	inline void Debug(std::string ctx, bool write = false)
-	{
+        inline void Debug(std::string_view ctx, bool write = false)
+        {
 #ifdef DBDEBUG
-		std::string line = "[Debug]" + ctx + '\n';
+                std::string line;
+                line.reserve(8 + ctx.size());
+                line.append("[Debug]");
+                line.append(ctx);
+                line.push_back('\n');
 
-		SetConsoleTextAttribute(hConsole, 9);
-		std::cout << line;
+                SetConsoleTextAttribute(hConsole, 9);
+                std::cout << line;
 
-		if (write)
+                if (write)
 			WriteLog(line);
 #endif
 	}
 
-	inline void Custom(std::string ctx, int color)
-	{
-		SetConsoleTextAttribute(hConsole, color);
-		std::cout << ctx << '\n';
-	}
+        inline void Custom(std::string_view ctx, int color)
+        {
+                SetConsoleTextAttribute(hConsole, color);
+                std::cout << ctx << '\n';
+        }
 
-	inline void PreviousLine()
-	{
-		HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-		CONSOLE_SCREEN_BUFFER_INFO csbi;
+        inline void PreviousLine()
+        {
+                CONSOLE_SCREEN_BUFFER_INFO csbi;
 
-		if (GetConsoleScreenBufferInfo(hConsole, &csbi)) {
-			csbi.dwCursorPosition.Y--;
-			SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
+                if (GetConsoleScreenBufferInfo(hConsole, &csbi)) {
+                        csbi.dwCursorPosition.Y--;
+                        SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
 
-			DWORD written;
-			FillConsoleOutputCharacter(hConsole, ' ', 80, csbi.dwCursorPosition, &written);
-			SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
-		}
-	}
+                        DWORD written;
+                        FillConsoleOutputCharacter(hConsole, ' ', static_cast<DWORD>(csbi.dwSize.X), csbi.dwCursorPosition, &written);
+                        SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
+                }
+        }
 }

--- a/DragonBurn-usermode/Helpers/WebApi.h
+++ b/DragonBurn-usermode/Helpers/WebApi.h
@@ -1,18 +1,21 @@
 #pragma once
+#include <array>
+#include <memory>
 #include <string>
+#include <string_view>
 #include <Windows.h>
-#include <vector>
 #include <regex>
 #include <stdexcept>
 
 namespace Web
 {
-    inline void Get(std::string url, std::string& response)
+    inline void Get(std::string_view url, std::string& response)
     {
-        response = "";
-        std::string cmd = "curl -s -X GET " + url;
+        response.clear();
+        std::string cmd("curl -s -X GET ");
+        cmd.append(url);
 
-        std::array<char, 128> buffer;
+        std::array<char, 256> buffer{};
         std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(cmd.c_str(), "r"), _pclose);
 
         if (!pipe)


### PR DESCRIPTION
## Summary
- modernized the Format helper to use RAII allocation and perfect forwarding, eliminating manual heap management
- reduced string copying in the logging and weapon icon helpers by switching to `std::string_view` and reusing console handles
- streamlined the web API helper by clearing buffers efficiently and expanding the curl read buffer

## Testing
- Not run (Windows-specific project; tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0169197188330ac7daf251e51e7b6