### PR TITLE
Revamp README with step-by-step onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,219 +1,225 @@
+# DragonBurn 2
+
 <p align="center">
-<img src="Assets/banner.png">
-</p>
-<p align="center">
-  <img src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white">
-  <img src="https://img.shields.io/badge/Visual_Studio-5C2D91?style=for-the-badge&logo=visual%20studio&logoColor=white">
-  <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white">
-  <img src="https://img.shields.io/badge/build-passing-76B900?style=for-the-badge&logo=&logoColor=whit">
-  <img src="https://img.shields.io/badge/tests-100/100-76B900?style=for-the-badge&logo=&logoColor=whit">
-  <img src="https://img.shields.io/badge/code quality-A+-76B900?style=for-the-badge&logo=&logoColor=whit">
-  <img src="https://img.shields.io/badge/license-MIT-blue?style=for-the-badge&logo=&logoColor=whit">
-  <img src="https://img.shields.io/badge/DragonBurn-v3.4.7.0-blue?style=for-the-badge&logo=&logoColor=whit">
-  <img src="https://img.shields.io/badge/CS2-000000?style=for-the-badge&logo=counter-strike&logoColor=white">
-  <img src="https://img.shields.io/badge/Kernel mode-28004D?style=for-the-badge">
-  <img src="https://img.shields.io/badge/offsets auto update-D06B57?style=for-the-badge">
-  <img src="https://img.shields.io/badge/undetected-03C75A?style=for-the-badge">
-  <img src="https://img.shields.io/badge/fullscreen-supported-76B900?style=for-the-badge">
+  <img src="Assets/banner.png" alt="DragonBurn banner">
 </p>
 
----
+DragonBurn is a Counter-Strike 2 external cheat that combines a user-mode overlay with a kernel-mode mapper. This README walks a new user through the entire workflow—from preparing Windows and building the binaries, to launching the tool and exploring every feature the menu exposes.
 
-<h3>
-<p align="center">
-DragonBurn is one of the best CS2 kernel mode read only external cheats. It has ton of features, full customization and offsets auto update. Undetected by all anti-cheats except faceit.
-</p></h3>
-
-<p align="center">
-<a href="https://github.com/ByteCorum/DragonBurn/releases/latest/download/DragonBurn.exe">Download latest release</a><br>
-⭐Please, star this repo if it was helpful⭐
-</p>
+> ⚠️ **Disclaimer:** The project is provided for educational purposes. Running it in online games breaks the CS2 terms of service and may result in bans, data loss, or other penalties. You are fully responsible for your own usage.
 
 ---
 
-### 🌐Join our community
+## 1. Project overview
 
-<a href="https://discord.gg/5WcvdzFybD"><img src="https://invidget.switchblade.xyz/5WcvdzFybD"></a>
+DragonBurn is split into two deliverables that must travel together:
 
-<a href="https://ko-fi.com/bytecorum"><img src="https://img.shields.io/badge/Support Author-F16061?style=for-the-badge&logo=ko-fi&logoColor=white"></a>
+- **`DragonBurn.exe`** – the user-mode DirectX 11 overlay built with C++20 and ImGui. It renders the menu, reads game data, applies aim/trigger/visual logic, and manages configuration files.
+- **`DragonBurn-kernel.exe`** – a kdmapper-based helper that loads the unsigned kernel driver powering DragonBurn's read/write primitives. The mapper must run with administrator rights before the overlay starts.
 
----
+The repository layout reflects that separation:
 
-### 📋 Features
-
-Press END key to open/close menu.
-
-<details>
-<summary>Visual</summary>
-  
-- Box ESP
-- Box Type
-- Box Rounding
-- Filled Box ESP
-- Gradient Filled Box ESP
-- Skeleton
-- Snap Line
-- Sound esp
-- Bomb esp
-- Bomb carrier esp
-- Visual Color
-- Eye Ray
-- Health Bar
-- Armor Bar
-- Weapon
-- Ammo
-- Distance
-- Name
-- Scoped
-- Blind
-- Blind Hide
-- AWP Crosshair
-- Visual Preview
-- etc
-</details>
-
-<details>
-<summary>Radar Hack</summary>
-  
-- Point Size
-- Proportion
-- Range
-- Alpha
-</details>
-
-<details>
-<summary>Aimbot</summary>
-  
-- Start Bullet
-- Aim Lock
-- Draw Fov
-- Visible Check
-- Auto Only
-- Flash Check
-- Scope Check
-- Humanization
-- FOV
-- Smooth
-- Multi Hitboxes Selection
-</details>
-
-<details>
-<summary>RCS</summary>
-  
-- Yaw
-- Pitch
-- Preview
-</details>
-
-<details>
-<summary>Trigger Bot</summary>
-  
-- Scope Check
-- Flash Check
-- Stop Check
-- Shot Delay
-- Shot Duration
-- TTD
-</details>
-
-<details>
-<summary>Misc</summary>
-  
-- Bomb Timer
-- Bunny Hop
-- Head Line
-- Hit Sound
-- Hit Markers
-- Auto knife
-- Auto zeus
-- Auto accept
-- Spectator list
-- Watermark
-- Anti Record
-</details>
+| Folder | What it contains |
+| --- | --- |
+| `DragonBurn-usermode/` | Main cheat source: rendering (ImGui), gameplay features (`Features/`), entity logic (`Game/`), memory manager, configuration UI, and saved-config logic (`Config/`). |
+| `DragonBurn-kernel/` | Mapper sources, driver resources, and helper utilities used to map the vulnerable Intel driver and load DragonBurn's kernel payload. |
+| `Crypto/` | Helper utilities for encrypting resources that ship with the overlay. |
+| `Assets/`, `imgs/` | Images used in the UI and documentation. |
+| `DragonBurn.sln`, `CMakeLists.txt` | Solution and cross-platform CMake project files that build both components. |
 
 ---
 
-### 🛠️How to use
+## 2. Quick start with the latest release
 
-At the beginning, download latest release or compile project by yourself. You need only 2 files `DragonBurn.exe` and `DragonBurn-kernel.exe`.
+1. **Download** the newest release archive from the [GitHub releases page](https://github.com/ByteCorum/DragonBurn/releases/latest) and extract it to an easy-to-remember folder (for example, `C:/DragonBurn`).
+2. **Place the files together:** the extracted folder must contain `DragonBurn.exe`, `DragonBurn-kernel.exe`, and the `Assets`/`imgs` directories. Do not separate the executables.
+3. **Prepare Windows (administrator required):**
+   - Close CS2 and any anti-cheat launchers (FaceIt, Vanguard, etc.).
+   - Temporarily disable real-time antivirus protection—Defender routinely flags mapper behaviour as malicious.
+4. **Run the kernel mapper:** right-click `DragonBurn-kernel.exe` → *Run as administrator*. A console window opens, maps the vulnerable `iqvw64e.sys` driver, and injects DragonBurn’s payload. Wait for a `"[+] success"` message before closing it. If it fails, consult the [Troubleshooting](#6-troubleshooting) section.
+5. **Launch CS2** and wait until you reach the main menu.
+6. **Start the overlay:** run `DragonBurn.exe`. On the first run DragonBurn creates a `Documents/DragonBurn/` folder for configs, checks the cheat/game version against the GitHub metadata, and downloads the latest offsets.
+7. **Toggle the menu:** press `END` to show/hide the overlay. Use the mouse to configure features, and enjoy.
 
-> [!NOTE]  
-> Kernel driver is close source for safety reasons, download it from release.
-
-Now you should run `DragonBurn-kernel.exe` to map the driver. If u see `[+] success` all fine, then just run `DragonBurn.exe` and gl hf.
-
----
-
-### ❌Errors
-
-<img src="imgs/error_1.png" width="400" height="90">
-
-> Error: `Windows Defender or any other anticheats may flag cheat as virus`
->
-> Solution: Turn off real-time protection
+You must repeat steps 3–7 every time you reboot or whenever the vulnerable driver unloads.
 
 ---
 
-### ❌Mapper errors
+## 3. Building DragonBurn from source
 
-cmd should be opened as admin
+> 💡 Building is only supported on 64-bit Windows. The CMake script aborts on other operating systems.
 
-> Error: `[-] \Device\Nal is already in use.`
->
-> Solution: Use [NalFix](https://github.com/VollRagm/NalFix)
+### 3.1 Prerequisites
 
-> Error: `[-] Your vulnerable driver list is enabled and have blocked the driver loading`
->
-> Solution: Disable vulnerable driver list, [official solution](https://support.microsoft.com/en-au/topic/kb5020779-the-vulnerable-driver-blocklist-after-the-october-2022-preview-release-3fcbe13a-6013-4118-b584-fcfbc6a09936)
+Install the following before cloning the repository:
 
-> Still getting: `[-] Failed to register and start service for the vulnerable driver`
->
-> Solution: Turn off all Anti-Viruses and all Anti-Cheats client, usually it caused by faceit ac
->
-> Faceit: `sc stop faceit`
-> Vanguard: `sc stop vgc` `sc stop vgk`
+- **Visual Studio 2022** with the *Desktop development with C++* workload and MSVC toolset v143.
+- **Windows 10/11 SDK** (10.0.19041 or newer). The SDK headers/libs are required by both the overlay and the mapper.
+- **Windows Driver Kit (WDK) 10** to compile the kernel mapper with elevated privileges.
+- **CMake 3.20+** (optional, only if you prefer generating the build with CMake instead of opening the solution directly).
+- **Git** to clone and manage the repository.
 
-> Error: `Driver is mapped successfully but failed to connect to kernel`
->
-> Solution: Reboot pc and manually run mapper with `--legacymethod`
+> ℹ️ DragonBurn targets modern builds of Windows 10 and Windows 11. The mapper has been validated up to Windows 11 24H2 26100.4351.
 
-> [!TIP]  
-> This cmds should fix any issue(after executing restart pc):
->
-> ```
-> reg add "HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\DeviceGuard" /v EnableVirtualizationBasedSecurity /t REG_DWORD /d 00000000 /f
-> bcdedit /set hypervisorlaunchtype off
-> reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\CI\Config" /v VulnerableDriverBlocklistEnable /t REG_DWORD /d 00000000 /f
-> ```
+### 3.2 Clone the repository
+
+```powershell
+cd C:/Projects
+git clone https://github.com/ByteCorum/DragonBurn.git DragonBurn
+cd DragonBurn
+```
+
+No submodules are required—the ImGui, STB, and JSON sources are already checked in under `DragonBurn-usermode/`.
+
+### 3.3 Build the user-mode overlay (Visual Studio GUI)
+
+1. Open `DragonBurn.sln` in Visual Studio 2022.
+2. When prompted, allow Visual Studio to generate CMake cache information.
+3. In the toolbar, pick the **`Release`** configuration and **`x64`** platform.
+4. Right-click the **DragonBurn** project in Solution Explorer and choose **Build**. Visual Studio compiles the overlay and drops `DragonBurn.exe` into `DragonBurn-usermode/Release/` (Debug builds land in `DragonBurn-usermode/Debug/`).
+5. Copy the produced `DragonBurn.exe` next to the mapper after you compile the kernel component.
+
+### 3.4 Build the user-mode overlay (CMake command line)
+
+If you prefer generating a Visual Studio solution with CMake:
+
+```powershell
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release --target DragonBurn
+```
+
+The resulting executable is written to `built/DragonBurn.exe` (or `built_dbg/` for Debug). This matches the output paths configured in `CMakeLists.txt`.
+
+### 3.5 Build the kernel mapper
+
+1. Ensure the **WDK** is installed—the mapper links against driver-specific libraries and requests administrator UAC elevation in the manifest.
+2. Still inside Visual Studio, right-click the **DragonBurn-kernel** project (listed under the “Kernel” solution folder) and build it in the **Release** configuration. Alternatively, build from the command line:
+
+   ```powershell
+   cmake --build build --config Release --target DragonBurn-kernel
+   ```
+
+3. The compiled mapper is placed in `DragonBurn-kernel/Release/DragonBurn-kernel.exe` (or `built/DragonBurn-kernel.exe` when using the CMake output path).
+4. Copy `DragonBurn-kernel.exe` to the same directory as the overlay executable before running the cheat.
+
+### 3.6 Ship the binaries together
+
+Collect these artefacts in a single folder:
+
+- `DragonBurn.exe`
+- `DragonBurn-kernel.exe`
+- The `Assets/` and `imgs/` folders (used for UI resources)
+- Any custom configuration files from `%USERPROFILE%/Documents/DragonBurn/`
+
+Launching the overlay without the mapper or without the resource folders will result in missing functionality.
 
 ---
 
-### 🖼️Preview
+## 4. Preparing Windows before each session
 
-<p align="center">
-<img src="imgs/img.png">
-</p>
+DragonBurn performs several environment checks during startup (see `Core/Init.h`). To avoid common pitfalls:
 
-<p align="center">
-<img src="imgs/img1.png">
-</p>
-
-<p align="center">
-<img src="imgs/img2.png">
-</p>
-
----
-
-### 📲Contacts
-
-<a href="https://github.com/ByteCorum"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white"></a>
-<a href="https://discordapp.com/users/798503509522645012"><img src="https://img.shields.io/badge/Discord-003E54?style=for-the-badge&logo=Discord&logoColor=white"></a>
+1. **Run everything as administrator.** The mapper requires elevated privileges to load the vulnerable Intel driver and register a temporary service.
+2. **Disable conflicting protections when troubleshooting:**
+   - Windows Defender real-time protection
+   - Third-party antivirus suites
+   - Anti-cheat services (e.g., FaceIt `sc stop faceit`, Riot Vanguard `sc stop vgc` & `sc stop vgk`)
+3. **Reboot if connection fails.** If DragonBurn cannot connect to the kernel driver after a successful map, restart Windows and relaunch the mapper with the optional `--legacymethod` flag.
+4. **Keep virtualization features off** when using the legacy mapper method. The repository documents the registry and `bcdedit` commands that disable the Microsoft vulnerable-driver blocklist when necessary.
+5. **Stay up-to-date.** DragonBurn verifies the cheat version and fetches the current CS2 offsets from GitHub (`a2x/cs2-dumper`) on launch, so an active internet connection is required the first time you run a new build.
 
 ---
 
-### 💸Support
+## 5. Using the overlay in CS2
 
-<a href="https://ko-fi.com/bytecorum"><img src="https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white"></a>
+Once the mapper has been executed and CS2 is running:
+
+1. **Start DragonBurn.exe.** The overlay attaches to `cs2.exe`, downloads offsets, and links to the mapped kernel driver to read game memory.
+2. **Open the menu** with the `END` key. Every tab is organised by feature type:
+   - `Visual` controls ESP, chams, colors, indicators, and overlay aesthetics.
+   - `Radar` configures the built-in 2D radar widget.
+   - `Aimbot`, `RCS`, and `Trigger` manage targeting assistance.
+   - `Misc` toggles automation helpers, quality-of-life tools, watermark, spectator list, etc.
+3. **Change options with your mouse.** Values update live—no restart needed.
+4. **Save or load configs** from the `Config` tab. Config files are JSON documents stored inside `%USERPROFILE%/Documents/DragonBurn/`. You can rename, delete, or share them freely.
+5. **Hide the UI** with `END` once you finish configuring. The cheat keeps running in the background.
 
 ---
+
+## 6. Feature catalog
+
+Each menu tab exposes a wide range of tweakable options. Below is a newcomer-friendly breakdown.
+
+### 6.1 Visual intelligence
+
+- **Box ESP / Filled / Gradient / Outline / Rounding** – draw 2D boxes around enemies with optional fill, gradient, and edge rounding controls.
+- **Skeleton** – render the player bone structure for precise positioning.
+- **Snap lines & Eye ray** – connect players to screen edges or draw their view direction to gauge awareness.
+- **Sound ESP** – display audio cues (footsteps, shots) as radial pings with custom colours.
+- **Bomb ESP & Carrier ESP** – highlight the C4 on the ground or the player carrying it.
+- **Health & Armour bars / numerical overlays** – monitor enemy vitals at a glance.
+- **Weapon, Ammo, Distance & Name tags** – append textual details beside ESP boxes.
+- **Scoped/Blind indicators + Blind Hide** – show when targets are scoped or flashed, with the option to hide ESP on blinded enemies.
+- **AWP crosshair & Preview widget** – enable an AWP-style crosshair for no-scope shots and preview changes inside the menu.
+- **Multi-colour & Out-of-FOV arrows** – customise visible/hidden colours and mark enemies outside of the screen.
+
+### 6.2 Radar awareness
+
+- **2D radar overlay** with adjustable range, scale, point size, alpha, and crosshair lines.
+- **Custom radar mode** that lets you reposition and resize the radar widget for multi-monitor setups.
+
+### 6.3 Aim assistance & recoil control
+
+- **Aimbot** – configure start-bullet thresholds, aim-lock, FOV, smoothing, visible checks, humanisation curves, multi-hitbox selection, and flash/scope gating.
+- **RCS (Recoil Control System)** – fine-tune pitch/yaw compensation with real-time previews so you can match your spray pattern.
+- **Trigger bot** – auto-fire when enemies cross your crosshair, including scope/flash/stop checks and granular delay/duration/TTD values.
+
+### 6.4 Miscellaneous helpers
+
+- **Bomb timer** – track plant/defuse progress with on-screen timers.
+- **Bunny hop & auto-strafe** – maintain momentum by automating jump inputs.
+- **Hit sound & hit markers** – audible and visual confirmation when your bullets connect.
+- **Auto-knife / auto-zeus** – automatically use knife or Zeus in lethal range.
+- **Auto-accept** – accept matchmaking queues instantly.
+- **Spectator list** – monitor who is watching you.
+- **Watermark & anti-record** – add overlay branding and block tools that capture the window.
+
+### 6.5 Configuration & automation
+
+- **Config saver/loader** – export all menu settings to JSON with author metadata (`Config/ConfigSaver.cpp`).
+- **Auto-offset updates** – download the latest offsets/buttons/class structures from GitHub (`Offsets/Offsets.cpp`).
+- **Version checks** – verify both DragonBurn and CS2 versions through remote metadata before enabling features (`Core/Init.h`).
+- **UI access helpers** – simulate mouse input safely on the overlay while keeping CS2 in focus (`Helpers/UIAccess.*`, `Helpers/Mouse.*`).
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Antivirus flags the files as malware | Defender or another AV is blocking the mapper. | Temporarily disable real-time protection while launching DragonBurn. |
+| `[-] \\Device\\Nal is already in use.` | A previous kdmapper instance or Intel driver is still loaded. | Reboot Windows or use [NalFix](https://github.com/VollRagm/NalFix) to release the handle before rerunning the mapper. |
+| `[-] Vulnerable driver list has blocked the driver` | Microsoft’s vulnerable driver blocklist is enabled. | Follow Microsoft’s guide to disable the blocklist or apply the registry edits documented in the mapper README. |
+| Mapper succeeds but DragonBurn cannot connect | Stale driver state or blocked IPC. | Reboot and rerun the mapper with `--legacymethod`. Ensure virtualization-based security is disabled. |
+| STATUS_IMAGE_CERT_REVOKED / 0xC0000603 | Windows rejected the vulnerable driver certificate. | Disable the vulnerable driver list in the registry and restart. |
+| Crash or no menu after CS2 update | Offsets are outdated. | Re-launch DragonBurn with an internet connection so it can download the newest offsets, or wait for the repository to publish compatible values. |
+
+If problems persist, inspect the console output of `DragonBurn.exe` for detailed log messages and check the `%USERPROFILE%/Documents/DragonBurn/logs/` folder (created when logging is enabled).
+
+---
+
+## 8. Community & support
+
+- **Discord:** [Join the community](https://discord.gg/5WcvdzFybD) for announcements and support.
+- **Ko-fi:** [Support the author](https://ko-fi.com/bytecorum) if DragonBurn proved useful.
+- **Issues & contributions:** Open GitHub issues or pull requests when you encounter reproducible bugs or have improvements to share.
+
+---
+
+## 9. License
+
+DragonBurn is released under the [MIT License](LICENSE). You are free to fork, modify, and redistribute the project as long as you retain the original copyright notice.
+
+---
+
+Happy tinkering, and remember to stay safe while experimenting.


### PR DESCRIPTION
## Summary
- replace the README with a newcomer-friendly overview of the project structure and deliverables
- document prerequisites and step-by-step instructions for building, running, and maintaining the cheat
- expand the feature catalog and troubleshooting information for common mapper issues

## Testing
- Not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e019679f108330a47ec01ac4d93126