### PR TITLE
Add selectable GUI themes

### DIFF
--- a/DragonBurn-usermode/Config/ConfigMenu.cpp
+++ b/DragonBurn-usermode/Config/ConfigMenu.cpp
@@ -188,10 +188,12 @@ namespace ConfigMenu {
 		ESPConfig::BoxColor = ImColor(59, 71, 148, 180);
 		ESPConfig::EyeRayColor = ImVec4(0, 98, 98, 255);
 
-		MenuConfig::ShowMenu = true;
-		MenuConfig::WorkInSpec = true;
+                MenuConfig::ShowMenu = true;
+                MenuConfig::WorkInSpec = true;
+                MenuConfig::Theme = 0;
+                MenuConfig::ThemeChanged = true;
 
-		RadarCFG::ShowRadar = false;
+                RadarCFG::ShowRadar = false;
 		RadarCFG::RadarRange = 125;
 		RadarCFG::ShowRadarCrossLine = false;
 		RadarCFG::RadarCrossLineColor = ImColor(131, 137, 150, 180);

--- a/DragonBurn-usermode/Config/ConfigSaver.cpp
+++ b/DragonBurn-usermode/Config/ConfigSaver.cpp
@@ -254,6 +254,8 @@ namespace MyConfigSaver
         ConfigData["MenuConfig"]["SpecWinPos"]["x"] = MenuConfig::SpecWinPos.x;
         ConfigData["MenuConfig"]["SpecWinPos"]["y"] = MenuConfig::SpecWinPos.y;
 
+        ConfigData["MenuConfig"]["Theme"] = MenuConfig::Theme;
+
         configFile << ConfigData.dump(4);
         configFile.close();
     }
@@ -520,6 +522,8 @@ namespace MyConfigSaver
             MenuConfig::BombWinChengePos = true;
             MenuConfig::RadarWinChengePos = true;
             MenuConfig::SpecWinChengePos = true;
+            MenuConfig::Theme = ReadData(ConfigData["MenuConfig"], { "Theme" }, 0);
+            MenuConfig::ThemeChanged = true;
         }
     }
 }

--- a/DragonBurn-usermode/Core/Config.h
+++ b/DragonBurn-usermode/Core/Config.h
@@ -28,14 +28,16 @@ namespace MenuConfig
 		ImVec2 ChildSize = ImVec2(540.f, 500.f);
 	} WCS;	// Window Component Settings
 
-	inline bool defaultConfig = false;
+        inline bool defaultConfig = false;
 
-	// 0: Window 1: Collapse
-	inline int WindowStyle = 0;
-	inline bool ShowMenu = true;
-	inline bool TeamCheck = true;
-	inline bool BypassOBS = false;
-	inline bool WorkInSpec = true;
+        // 0: Window 1: Collapse
+        inline int WindowStyle = 0;
+        inline int Theme = 0; // 0: DragonBurn, 1: Dark, 2: Light
+        inline bool ThemeChanged = false;
+        inline bool ShowMenu = true;
+        inline bool TeamCheck = true;
+        inline bool BypassOBS = false;
+        inline bool WorkInSpec = true;
 
 	inline ImVec2 MarkWinPos;
 	inline ImVec2 RadarWinPos;

--- a/DragonBurn-usermode/Core/GUI.h
+++ b/DragonBurn-usermode/Core/GUI.h
@@ -86,15 +86,179 @@ namespace GUI
 	{
 		AimControl::HitboxList.push_back(BoneIndex);
 	}
-	void removeHitbox(int BoneIndex)
-	{
-		for (auto it = AimControl::HitboxList.begin(); it != AimControl::HitboxList.end(); ++it) {
-			if (*it == BoneIndex) {
-				AimControl::HitboxList.erase(it);
-				break;
-			}
-		}
-	}
+        void removeHitbox(int BoneIndex)
+        {
+                for (auto it = AimControl::HitboxList.begin(); it != AimControl::HitboxList.end(); ++it) {
+                        if (*it == BoneIndex) {
+                                AimControl::HitboxList.erase(it);
+                                break;
+                        }
+                }
+        }
+
+        inline void ApplyCommonThemeStyle(ImGuiStyle& style)
+        {
+                style.Alpha = 1.0f;
+                style.DisabledAlpha = 0.8f;
+                style.WindowPadding = ImVec2(0.f, 0.f);
+                style.WindowRounding = 12.0f;
+                style.WindowBorderSize = 1.0f;
+                style.WindowMinSize = ImVec2(32.0f, 32.0f);
+                style.WindowTitleAlign = ImVec2(0.5f, 0.5f);
+                style.WindowMenuButtonPosition = ImGuiDir_Left;
+                style.ChildRounding = 12.0f;
+                style.ChildBorderSize = 1.0f;
+                style.PopupRounding = 4.0f;
+                style.PopupBorderSize = 1.0f;
+                style.FramePadding = ImVec2(5.0f, 1.0f);
+                style.FrameRounding = 5.0f;
+                style.FrameBorderSize = 1.0f;
+                style.ItemSpacing = ImVec2(6.0f, 4.0f);
+                style.ItemInnerSpacing = ImVec2(4.0f, 4.0f);
+                style.CellPadding = ImVec2(4.0f, 2.0f);
+                style.IndentSpacing = 21.0f;
+                style.ColumnsMinSpacing = 6.0f;
+                style.ScrollbarSize = 13.0f;
+                style.ScrollbarRounding = 16.0f;
+                style.GrabMinSize = 20.0f;
+                style.GrabRounding = 5.0f;
+                style.TabRounding = 4.0f;
+                style.TabBorderSize = 1.0f;
+                style.TabMinWidthForCloseButton = 0.0f;
+                style.ColorButtonPosition = ImGuiDir_Right;
+                style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+                style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+        }
+
+        void ApplyTheme(int themeIndex)
+        {
+                if (themeIndex == 0)
+                {
+                        ImGui::DragonBurnDefaultStyle();
+                        MenuConfig::ThemeChanged = false;
+                        return;
+                }
+
+                if (themeIndex == 1)
+                        ImGui::StyleColorsDark();
+                else
+                        ImGui::StyleColorsLight();
+
+                ImGuiStyle& style = ImGui::GetStyle();
+                ApplyCommonThemeStyle(style);
+
+                ImVec4* colors = style.Colors;
+                if (themeIndex == 1)
+                {
+                        const ImVec4 accent = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+                        colors[ImGuiCol_Text] = ImVec4(0.94f, 0.95f, 0.98f, 1.00f);
+                        colors[ImGuiCol_TextDisabled] = ImVec4(0.55f, 0.60f, 0.68f, 1.00f);
+                        colors[ImGuiCol_WindowBg] = ImVec4(0.07f, 0.08f, 0.11f, 1.00f);
+                        colors[ImGuiCol_ChildBg] = ImVec4(0.09f, 0.10f, 0.14f, 1.00f);
+                        colors[ImGuiCol_PopupBg] = ImVec4(0.09f, 0.10f, 0.14f, 1.00f);
+                        colors[ImGuiCol_Border] = ImVec4(0.16f, 0.18f, 0.22f, 1.00f);
+                        colors[ImGuiCol_BorderShadow] = ImVec4(0.07f, 0.08f, 0.11f, 1.00f);
+                        colors[ImGuiCol_FrameBg] = ImVec4(0.12f, 0.14f, 0.20f, 1.00f);
+                        colors[ImGuiCol_FrameBgHovered] = ImVec4(0.19f, 0.23f, 0.31f, 1.00f);
+                        colors[ImGuiCol_FrameBgActive] = ImVec4(0.21f, 0.28f, 0.39f, 1.00f);
+                        colors[ImGuiCol_TitleBg] = ImVec4(0.10f, 0.12f, 0.16f, 1.00f);
+                        colors[ImGuiCol_TitleBgActive] = ImVec4(0.10f, 0.12f, 0.16f, 1.00f);
+                        colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.07f, 0.08f, 0.11f, 1.00f);
+                        colors[ImGuiCol_MenuBarBg] = ImVec4(0.08f, 0.10f, 0.13f, 1.00f);
+                        colors[ImGuiCol_ScrollbarBg] = ImVec4(0.05f, 0.06f, 0.08f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.15f, 0.18f, 0.24f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.21f, 0.26f, 0.33f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.26f, 0.32f, 0.42f, 1.00f);
+                        colors[ImGuiCol_CheckMark] = accent;
+                        colors[ImGuiCol_SliderGrab] = accent;
+                        colors[ImGuiCol_SliderGrabActive] = ImVec4(0.35f, 0.68f, 1.00f, 1.00f);
+                        colors[ImGuiCol_Button] = ImVec4(0.15f, 0.21f, 0.30f, 1.00f);
+                        colors[ImGuiCol_ButtonHovered] = ImVec4(0.23f, 0.31f, 0.43f, 1.00f);
+                        colors[ImGuiCol_ButtonActive] = ImVec4(0.33f, 0.46f, 0.63f, 1.00f);
+                        colors[ImGuiCol_Header] = ImVec4(0.18f, 0.25f, 0.35f, 1.00f);
+                        colors[ImGuiCol_HeaderHovered] = ImVec4(0.26f, 0.34f, 0.46f, 1.00f);
+                        colors[ImGuiCol_HeaderActive] = ImVec4(0.33f, 0.46f, 0.63f, 1.00f);
+                        colors[ImGuiCol_Separator] = ImVec4(0.14f, 0.18f, 0.25f, 1.00f);
+                        colors[ImGuiCol_SeparatorHovered] = ImVec4(0.26f, 0.34f, 0.46f, 1.00f);
+                        colors[ImGuiCol_SeparatorActive] = ImVec4(0.33f, 0.46f, 0.63f, 1.00f);
+                        colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.34f, 0.46f, 0.60f);
+                        colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.33f, 0.46f, 0.63f, 0.80f);
+                        colors[ImGuiCol_ResizeGripActive] = ImVec4(0.33f, 0.46f, 0.63f, 1.00f);
+                        colors[ImGuiCol_Tab] = ImVec4(0.16f, 0.23f, 0.33f, 1.00f);
+                        colors[ImGuiCol_TabHovered] = ImVec4(0.33f, 0.46f, 0.63f, 1.00f);
+                        colors[ImGuiCol_TabActive] = ImVec4(0.24f, 0.34f, 0.48f, 1.00f);
+                        colors[ImGuiCol_TabUnfocused] = ImVec4(0.12f, 0.17f, 0.24f, 1.00f);
+                        colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.20f, 0.28f, 0.39f, 1.00f);
+                        colors[ImGuiCol_TableHeaderBg] = ImVec4(0.18f, 0.25f, 0.35f, 1.00f);
+                        colors[ImGuiCol_TableBorderStrong] = ImVec4(0.12f, 0.17f, 0.24f, 1.00f);
+                        colors[ImGuiCol_TableBorderLight] = ImVec4(0.10f, 0.14f, 0.20f, 1.00f);
+                        colors[ImGuiCol_TableRowBg] = ImVec4(0.11f, 0.14f, 0.20f, 1.00f);
+                        colors[ImGuiCol_TableRowBgAlt] = ImVec4(0.14f, 0.18f, 0.25f, 1.00f);
+                        colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+                        colors[ImGuiCol_DragDropTarget] = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+                        colors[ImGuiCol_NavHighlight] = accent;
+                        colors[ImGuiCol_NavWindowingHighlight] = ImVec4(0.66f, 0.71f, 0.76f, 0.70f);
+                        colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.04f, 0.04f, 0.04f, 0.65f);
+                        colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.05f, 0.05f, 0.05f, 0.70f);
+                        colors[ImGuiCol_WindowShadow] = ImVec4(0.02f, 0.02f, 0.02f, 0.50f);
+                }
+                else
+                {
+                        const ImVec4 accent = ImVec4(0.20f, 0.45f, 0.88f, 1.00f);
+                        colors[ImGuiCol_Text] = ImVec4(0.16f, 0.21f, 0.28f, 1.00f);
+                        colors[ImGuiCol_TextDisabled] = ImVec4(0.58f, 0.62f, 0.70f, 1.00f);
+                        colors[ImGuiCol_WindowBg] = ImVec4(0.97f, 0.98f, 1.00f, 1.00f);
+                        colors[ImGuiCol_ChildBg] = ImVec4(0.95f, 0.97f, 1.00f, 1.00f);
+                        colors[ImGuiCol_PopupBg] = ImVec4(0.98f, 0.99f, 1.00f, 0.98f);
+                        colors[ImGuiCol_Border] = ImVec4(0.78f, 0.82f, 0.90f, 1.00f);
+                        colors[ImGuiCol_BorderShadow] = ImVec4(0.90f, 0.93f, 0.98f, 1.00f);
+                        colors[ImGuiCol_FrameBg] = ImVec4(0.87f, 0.91f, 1.00f, 1.00f);
+                        colors[ImGuiCol_FrameBgHovered] = ImVec4(0.80f, 0.86f, 0.99f, 1.00f);
+                        colors[ImGuiCol_FrameBgActive] = ImVec4(0.73f, 0.82f, 0.99f, 1.00f);
+                        colors[ImGuiCol_TitleBg] = ImVec4(0.89f, 0.93f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TitleBgActive] = ImVec4(0.82f, 0.88f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.94f, 0.96f, 1.00f, 1.00f);
+                        colors[ImGuiCol_MenuBarBg] = ImVec4(0.90f, 0.94f, 1.00f, 1.00f);
+                        colors[ImGuiCol_ScrollbarBg] = ImVec4(0.86f, 0.90f, 0.98f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.70f, 0.78f, 0.92f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.62f, 0.73f, 0.92f, 1.00f);
+                        colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.54f, 0.67f, 0.88f, 1.00f);
+                        colors[ImGuiCol_CheckMark] = accent;
+                        colors[ImGuiCol_SliderGrab] = accent;
+                        colors[ImGuiCol_SliderGrabActive] = ImVec4(0.29f, 0.55f, 0.94f, 1.00f);
+                        colors[ImGuiCol_Button] = ImVec4(0.87f, 0.91f, 1.00f, 1.00f);
+                        colors[ImGuiCol_ButtonHovered] = ImVec4(0.79f, 0.86f, 0.99f, 1.00f);
+                        colors[ImGuiCol_ButtonActive] = ImVec4(0.70f, 0.80f, 0.95f, 1.00f);
+                        colors[ImGuiCol_Header] = ImVec4(0.84f, 0.89f, 1.00f, 1.00f);
+                        colors[ImGuiCol_HeaderHovered] = ImVec4(0.78f, 0.85f, 0.99f, 1.00f);
+                        colors[ImGuiCol_HeaderActive] = ImVec4(0.70f, 0.80f, 0.95f, 1.00f);
+                        colors[ImGuiCol_Separator] = ImVec4(0.74f, 0.80f, 0.90f, 1.00f);
+                        colors[ImGuiCol_SeparatorHovered] = ImVec4(0.64f, 0.74f, 0.92f, 1.00f);
+                        colors[ImGuiCol_SeparatorActive] = ImVec4(0.54f, 0.67f, 0.88f, 1.00f);
+                        colors[ImGuiCol_ResizeGrip] = ImVec4(0.68f, 0.78f, 0.94f, 0.60f);
+                        colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.56f, 0.70f, 0.92f, 0.80f);
+                        colors[ImGuiCol_ResizeGripActive] = ImVec4(0.48f, 0.64f, 0.90f, 1.00f);
+                        colors[ImGuiCol_Tab] = ImVec4(0.84f, 0.89f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TabHovered] = ImVec4(0.78f, 0.85f, 0.99f, 1.00f);
+                        colors[ImGuiCol_TabActive] = ImVec4(0.74f, 0.83f, 0.97f, 1.00f);
+                        colors[ImGuiCol_TabUnfocused] = ImVec4(0.92f, 0.95f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.80f, 0.87f, 0.97f, 1.00f);
+                        colors[ImGuiCol_TableHeaderBg] = ImVec4(0.84f, 0.89f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TableBorderStrong] = ImVec4(0.78f, 0.82f, 0.90f, 1.00f);
+                        colors[ImGuiCol_TableBorderLight] = ImVec4(0.86f, 0.90f, 0.96f, 1.00f);
+                        colors[ImGuiCol_TableRowBg] = ImVec4(0.95f, 0.97f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TableRowBgAlt] = ImVec4(0.90f, 0.94f, 1.00f, 1.00f);
+                        colors[ImGuiCol_TextSelectedBg] = ImVec4(0.35f, 0.56f, 0.98f, 0.35f);
+                        colors[ImGuiCol_DragDropTarget] = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+                        colors[ImGuiCol_NavHighlight] = accent;
+                        colors[ImGuiCol_NavWindowingHighlight] = ImVec4(0.53f, 0.61f, 0.74f, 0.45f);
+                        colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.82f, 0.87f, 0.20f);
+                        colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.82f, 0.87f, 0.35f);
+                        colors[ImGuiCol_WindowShadow] = ImVec4(0.80f, 0.85f, 0.92f, 0.35f);
+                }
+
+                MenuConfig::ThemeChanged = false;
+        }
 
 	void LoadImages()
 	{
@@ -198,10 +362,13 @@ namespace GUI
 	}
 	// ########################################
 
-	void DrawGui()
-	{
-		LoadImages();
-		ImTextureID ImageID;
+        void DrawGui()
+        {
+                if (MenuConfig::ThemeChanged)
+                        ApplyTheme(MenuConfig::Theme);
+
+                LoadImages();
+                ImTextureID ImageID;
 		ImVec2 LogoSize, LogoPos;
 
 		ImageID = (void*)Logo;
@@ -664,12 +831,20 @@ namespace GUI
 							KeyMgr::GetPressedKey(MenuConfig::HotKey, &Text::Misc::HotKey);
 							}).detach();
 					}
-					PutSwitch(Text::Misc::SpecCheck.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::WorkInSpec);
-					PutSwitch(Text::Misc::TeamCheck.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::TeamCheck);
-					PutSwitch(Text::Misc::AntiRecord.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::BypassOBS);
-					ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5.f);
+                                        PutSwitch(Text::Misc::SpecCheck.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::WorkInSpec);
+                                        PutSwitch(Text::Misc::TeamCheck.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::TeamCheck);
+                                        PutSwitch(Text::Misc::AntiRecord.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::BypassOBS);
+                                        ImGui::TextDisabled(Text::Misc::Theme.c_str());
+                                        ImGui::SameLine();
+                                        AlignRight(160.f);
+                                        ImGui::SetNextItemWidth(160.f);
+                                        if (ImGui::Combo("###MenuTheme", &MenuConfig::Theme, "DragonBurn\0Dark\0Light\0"))
+                                        {
+                                                ApplyTheme(MenuConfig::Theme);
+                                        }
+                                        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5.f);
 
-					ImGui::NewLine();
+                                        ImGui::NewLine();
 					if (ImGui::Button("Source Code", { 125.f, 25.f }))
 						Gui.OpenWebpage("https://github.com/ByteCorum/DragonBurn");
 					ImGui::SameLine();

--- a/DragonBurn-usermode/Resources/Language.h
+++ b/DragonBurn-usermode/Resources/Language.h
@@ -137,6 +137,7 @@ namespace Text {
         inline std::string AutoBotDistance = "Distance";
         inline std::string AntiAFK = "Anti AFK";
         inline std::string AntiAFKInterval = "Interval";
+        inline std::string Theme = "Menu Theme";
         inline std::string InsecureTip = "This option may trigger VAC Live";
     }
 


### PR DESCRIPTION
## Summary
- add a theme picker to the GUI global settings with DragonBurn, Dark, and Light presets
- apply the selected style at runtime and persist it through config load/save as well as reset defaults
- introduce shared styling helpers for consistent rounding and spacing between the themes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e01c4746f48330a9ae59670a153a52